### PR TITLE
Set the mock Slim instance as the default instance

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,9 @@ class LocalWebTestCase extends WebTestCase {
           'mode'           => 'testing',
           'templates.path' => __DIR__ . '/../app/templates'
       ));
+      
+      // Make this the instance returned by Slim::getInstance()
+      $app->setName('default');
 
       // Include our core application file
       require PROJECT_ROOT . '/app/app.php';


### PR DESCRIPTION
A lot of Slim middleware code relies on `Slim::getInstance()`, so when creating a mock Slim instance we should set its name to `'default'` so that future `Slim::getInstance()` calls return the current mocked Slim instance.
