### PR TITLE
Added $app->setName('default');

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,16 +14,20 @@ require_once PROJECT_ROOT . '/vendor/autoload.php';
 // Initialize our own copy of the slim application
 class LocalWebTestCase extends WebTestCase {
     public function getSlimInstance() {
-      $app = new \Slim\Slim(array(
-          'version'        => '0.0.0',
-          'debug'          => false,
-          'mode'           => 'testing',
-          'templates.path' => __DIR__ . '/../app/templates'
-      ));
+        $app = new \Slim\Slim(array(
+            'version'        => '0.0.0',
+            'debug'          => false,
+            'mode'           => 'testing',
+            'templates.path' => __DIR__ . '/../app/templates'
+        ));
 
-      // Include our core application file
-      require PROJECT_ROOT . '/app/app.php';
-      return $app;
+        // force to overwrite the App singleton, so that \Slim\Slim::getInstance()
+        // returns the correct instance.
+        $app->setName('default');
+
+        // Include our core application file
+        require PROJECT_ROOT . '/app/app.php';
+        return $app;
     }
 };
 


### PR DESCRIPTION
I ran into a problem today using a custom view that calls \Slim\Slim::getInstance();

There were a few others with the same issue here:
https://disqus.com/home/discussion/there4/unit_testing_slim_php_framework_applications_with_phpunit_26/

It just required adding $app->setName('default'); to LocalWebTestCase.

It looks like this was already added to WebTestCase::getSlimInstance(), but was not in the example code that overrides that.